### PR TITLE
📝Adição da ata referente a reunião de inspeção do grupo 9

### DIFF
--- a/docs/atas/ata04.md
+++ b/docs/atas/ata04.md
@@ -1,0 +1,43 @@
+# Ata da Reunião de Inspeção do Grupo 09 de Requisitos de Software – Grupo 08
+
+### Local
+Reunião realizada online via **Microsoft Teams**.
+
+### Horário da Reunião
+|          | Data       | Início| Término |
+|----------|------------|-------|---------|
+| Previsto | 14/04/2025 | 20:00 | 21:00   |
+| Realizado| 14/04/2025 | 20:00 | 21:10  |
+
+## Participantes presentes:
+- [x] [Ana Victória Guedes da Costa](https://github.com/navicg)
+- [x] [Artur Mendonça Arruda](https://github.com/ArtyMend07)
+- [x] [Gabriel Lopes](https://github.com/BrzGab)
+- [x] [João Marcos Moraes de Andrade](https://github.com/JJOAOMARCOSS)
+- [x] [Lucas Mendonça Arruda](https://github.com/lucasarruda9)
+- [x] [Luiza da Silva Pugas](https://github.com/Luizaxx)
+
+## Pauta:
+* Realização da inspeção do grupo 9 (aplicativo Sinesp).
+* Planejamento da apresentação da primeira etapa do projeto.
+* Discussão sobre a organização do repositório do projeto no GitHub.
+
+## Decisões:
+* A inspeção do grupo 9, referente ao aplicativo Sinesp, foi concluída.
+* Gabriel ficou responsável por elaborar o artefato de verificação da inspeçã.
+* Artur ficou encarregado de editar o vídeo da inspeção e enviar o documento correspondente da inspeção pela plataforma Aprender.
+
+## Bibliografia:
+
+UNIVERSIDADE DE BRASÍLIA. FGA0313 – Requisitos de Software – Turma T03 (2025.1 – 35M12). Docente: ANDRE BARROS DE SALES. Plano de ensino disponível em: [Plano de Ensino](https://aprender3.unb.br/pluginfile.php/3095981/mod_resource/content/57/FGA0303-T03.pdf). Acesso em: 15 abr. 2025.
+
+## Link da gravação
+[Reunião de Inspeção do grupo 9(Sinesp)](https://youtu.be/5b8SrFMpjB8)
+
+## Próxima Reunião
+A definir.
+
+## Histórico de versão
+| Versão | Data | Descrição | Autor(es) | Revisor(es) |
+|--------|------|-----------|-----------|-------------|
+| 1.0 | 15/04/2025 | Ata da Reunião da Inspeção do grupo 9.| [Ana Victória Guedes da Costa](https://github.com/navicg)| [Lucas Mendonça Arruda](https://github.com/lucasarruda9)|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
     - Ata 1: atas/ata01.md
     - Ata 2: atas/ata02.md
     - Ata 3: atas/ata03.md
+    - Ata 4: atas/ata04.md
   - Pré-Rastreabilidade: 
     - Rich Picture: pre-rastreabilidade/rich_picture.md
   - Planejamento:


### PR DESCRIPTION
# :rocket: Ata referente a Reunião de Inspeção do Grupo 9

## :clipboard: Descrição
Essa Pull Request adiciona a ata da reunião de inspeção do grupo 9 de requisitos do Grupo 08, realizada em 14 de abril de 2025 via Microsoft Teams. O documento detalha os participantes presentes, os tópicos discutidos, decisões tomadas, o link da gravação, a bibliografia utilizada e o histórico de versão da ata.

## :wrench: Tarefas Realizadas
- [x] Definir os pontos principais das reuniões.
- [x] Redigir a ata.
- [x] Atualizar histórico de versões.

## :pushpin: Problema Relacionado
Closes #46 .

## :mag: Mudanças Realizadas
* Adição da ata da reunião de inspeção do grupo em formato Markdown.
* Estruturação da ata conforme o padrão definido: local, horário, participantes, pauta, decisões, link de gravação e histórico de versão.
* Registro da versão 1.0 com autoria e revisão identificadas.

## :busts_in_silhouette: Revisores
- [Lucas Mendonça Arruda](@lucasarruda9 )