### PR TITLE
Docs/lexico

### DIFF
--- a/docs/modelagem/lexico.md
+++ b/docs/modelagem/lexico.md
@@ -67,7 +67,7 @@ Para a elaboração deste léxico do sistema eGDF, adotou-se a notação do Léx
 
 | Campo     | Descrição |
 |-----------|-----------|
-| **Símbolo**   | [Login](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/brainstorming.md#anchor_BS), [AD01](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/analise_documentos.md#anchor_AD) |
+| **Símbolo**   | [Login](../elicitacao/tec_elicitacao/brainstorming.md#anchor_BS), [AD01](../elicitacao/tec_elicitacao/analise_documentos.md#anchor_AD) |
 | **Noção**     | Processo de autenticação do usuário no sistema através da plataforma gov.br, com opções como reconhecimento facial. |
 | **Impacto**   | Permite o acesso seguro às funcionalidades do aplicativo, garantindo a privacidade dos dados do usuário e uma experiência fluida. |
 | **Sinônimos** | Autenticação, Acesso |
@@ -86,7 +86,7 @@ Para a elaboração deste léxico do sistema eGDF, adotou-se a notação do Léx
 
 | Campo     | Descrição |
 |-----------|-----------|
-| **Símbolo**   | [Agendamento](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/brainstorming.md#anchor_BS) |
+| **Símbolo**   | [Agendamento](../elicitacao/tec_elicitacao/brainstorming.md#anchor_BS) |
 | **Noção**     | Marcação de horário para serviços específicos, como atendimentos em órgãos públicos. |
 | **Impacto**   | Permite ao usuário organizar seus compromissos com serviços públicos de forma centralizada e eficiente. |
 | **Sinônimos** | Marcação, Agenda |
@@ -105,7 +105,7 @@ Para a elaboração deste léxico do sistema eGDF, adotou-se a notação do Léx
 
 | Campo     | Descrição |
 |-----------|-----------|
-| **Símbolo**   | [Serviços](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/introspeccao.md#anchor_INT) |
+| **Símbolo**   | [Serviços](../elicitacao/tec_elicitacao/introspeccao.md#anchor_INT) |
 | **Noção**     | Sistema que permite ao usuário avaliar e comentar sobre os serviços públicos utilizados. |
 | **Impacto**   | Fornece feedback para melhorias nos serviços e transparência na gestão pública. |
 | **Sinônimos** | Feedback, Avaliação |
@@ -123,7 +123,7 @@ Para a elaboração deste léxico do sistema eGDF, adotou-se a notação do Léx
 
 | Campo     | Descrição |
 |-----------|-----------|
-| **Símbolo**   | [Compartilhamento](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/brainstorming.md#anchor_BS) |
+| **Símbolo**   | [Compartilhamento](../elicitacao/tec_elicitacao/brainstorming.md#anchor_BS) |
 | **Noção**     | Ação de distribuir informações do sistema com outros usuários, como protocolos ou comprovantes. |
 | **Impacto**   | Facilita a comunicação e troca de informações entre usuários, promovendo colaboração. |
 | **Sinônimos** | Distribuição, Envio |
@@ -143,7 +143,7 @@ Para a elaboração deste léxico do sistema eGDF, adotou-se a notação do Léx
 
 | Campo     | Descrição |
 |-----------|-----------|
-| **Símbolo**   | [Notificação](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/brainstorming.md#anchor_BS) |
+| **Símbolo**   | [Notificação](../elicitacao/tec_elicitacao/brainstorming.md#anchor_BS) |
 | **Noção**     | Alerta ou mensagem enviada ao usuário sobre eventos relevantes, personalizada com base em sua localização. |
 | **Impacto**   | Mantém o usuário informado sobre atualizações, lembretes e eventos importantes relacionados aos serviços. |
 | **Sinônimos** | Alerta, Aviso |
@@ -162,7 +162,7 @@ Para a elaboração deste léxico do sistema eGDF, adotou-se a notação do Léx
 
 | Campo     | Descrição |
 |-----------|-----------|
-| **Símbolo**   | [Funcionalidades Educacionais](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/entrevista.md#anchor_EN06) |
+| **Símbolo**   | [Funcionalidades Educacionais](../elicitacao/tec_elicitacao/entrevista.md#anchor_EN06) |
 | **Noção**     | Recursos específicos para acompanhamento de pendências de professores e alunos. |
 | **Impacto**   | Melhora a gestão e acompanhamento das atividades educacionais. |
 | **Sinônimos** | Recursos Educacionais |
@@ -179,7 +179,7 @@ Para a elaboração deste léxico do sistema eGDF, adotou-se a notação do Léx
 
 | Campo     | Descrição |
 |-----------|-----------|
-| **Símbolo**   | [Mapa Interativo](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/entrevista.md#anchor_EN09) |
+| **Símbolo**   | [Mapa Interativo](../elicitacao/tec_elicitacao/entrevista.md#anchor_EN09) |
 | **Noção**     | Interface para reportar problemas urbanos através de um mapa. |
 | **Impacto**   | Facilita a identificação e registro de problemas na cidade. |
 | **Sinônimos** | Mapa de Ocorrências |
@@ -195,7 +195,7 @@ Para a elaboração deste léxico do sistema eGDF, adotou-se a notação do Léx
 
 | Campo     | Descrição |
 |-----------|-----------|
-| **Símbolo**   | [Assistente Virtual](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/brainstorming.md#anchor_BS), [AD05](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/analise_documentos.md#anchor_AD), [INT13](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/introspeccao.md#anchor_INT) |
+| **Símbolo**   | [Assistente Virtual](../elicitacao/tec_elicitacao/brainstorming.md#anchor_BS), [AD05](../elicitacao/tec_elicitacao/analise_documentos.md#anchor_AD), [INT13](../elicitacao/tec_elicitacao/introspeccao.md#anchor_INT) |
 | **Noção**     | Sistema automatizado que auxilia o usuário através de interações por voz ou texto, com respostas automáticas para dúvidas frequentes. |
 | **Impacto**   | Fornece suporte e orientação aos usuários, facilitando a navegação e resolução de dúvidas. |
 | **Sinônimos** | Chatbot, Ajudante Virtual |
@@ -212,7 +212,7 @@ Para a elaboração deste léxico do sistema eGDF, adotou-se a notação do Léx
 
 | Campo     | Descrição |
 |-----------|-----------|
-| **Símbolo**   | [Tutorial](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/brainstorming.md#anchor_BS) |
+| **Símbolo**   | [Tutorial](../elicitacao/tec_elicitacao/brainstorming.md#anchor_BS) |
 | **Noção**     | Guia passo a passo sobre como utilizar as funcionalidades do aplicativo. |
 | **Impacto**   | Ajuda novos usuários a compreenderem as funcionalidades do sistema, reduzindo a necessidade de suporte externo. |
 | **Sinônimos** | Guia, Manual |
@@ -229,7 +229,7 @@ Para a elaboração deste léxico do sistema eGDF, adotou-se a notação do Léx
 
 | Campo     | Descrição |
 |-----------|-----------|
-| **Símbolo**   | [Relatório](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/brainstorming.md#anchor_BS) |
+| **Símbolo**   | [Relatório](../elicitacao/tec_elicitacao/brainstorming.md#anchor_BS) |
 | **Noção**     | Documento gerado contendo informações sobre atividades do usuário, como agendamentos e solicitações. |
 | **Impacto**   | Permite ao usuário acompanhar suas interações e serviços utilizados. |
 | **Sinônimos** | Comprovante, Registro |
@@ -246,7 +246,7 @@ Para a elaboração deste léxico do sistema eGDF, adotou-se a notação do Léx
 
 | Campo     | Descrição |
 |-----------|-----------|
-| **Símbolo**   | [Preferência](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/brainstorming.md#anchor_BS) |
+| **Símbolo**   | [Preferência](../elicitacao/tec_elicitacao/brainstorming.md#anchor_BS) |
 | **Noção**     | Configurações personalizadas do usuário para adaptar o sistema às suas necessidades. |
 | **Impacto**   | Adapta o sistema às necessidades específicas de cada usuário, melhorando a experiência. |
 | **Sinônimos** | Configuração, Personalização |
@@ -263,7 +263,7 @@ Para a elaboração deste léxico do sistema eGDF, adotou-se a notação do Léx
 
 | Campo     | Descrição |
 |-----------|-----------|
-| **Símbolo**   | [Lembretes](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/brainstorming.md#anchor_BS) |
+| **Símbolo**   | [Lembretes](../elicitacao/tec_elicitacao/brainstorming.md#anchor_BS) |
 | **Noção**     | Alertas sobre eventos futuros ou pendências importantes para o usuário. |
 | **Impacto**   | Mantém o usuário informado sobre compromissos e prazos importantes. |
 | **Sinônimos** | Alertas, Notificações |
@@ -283,7 +283,7 @@ Para a elaboração deste léxico do sistema eGDF, adotou-se a notação do Léx
 
 | Campo     | Descrição |
 |-----------|-----------|
-| **Símbolo**   | [Acessibilidade](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/brainstorming.md#anchor_BS), [EN08](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/entrevista.md#anchor_EN), [AD08](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/analise_documentos.md#anchor_AD) |
+| **Símbolo**   | [Acessibilidade](../elicitacao/tec_elicitacao/brainstorming.md#anchor_BS), [EN08](../elicitacao/tec_elicitacao/entrevista.md#anchor_EN), [AD08](../elicitacao/tec_elicitacao/analise_documentos.md#anchor_AD) |
 | **Noção**     | Recursos que tornam o aplicativo utilizável por pessoas com diferentes necessidades. |
 | **Impacto**   | Garante que o sistema possa ser utilizado por todos os usuários, promovendo inclusão digital. |
 | **Sinônimos** | Inclusão Digital |
@@ -300,7 +300,7 @@ Para a elaboração deste léxico do sistema eGDF, adotou-se a notação do Léx
 
 | Campo     | Descrição |
 |-----------|-----------|
-| **Símbolo**   | [Modo Escuro](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/brainstorming.md#anchor_BS) |
+| **Símbolo**   | [Modo Escuro](../elicitacao/tec_elicitacao/brainstorming.md#anchor_BS) |
 | **Noção**     | Tema visual com cores escuras para reduzir o brilho da tela. |
 | **Impacto**   | Melhora a experiência do usuário em ambientes com pouca luz, reduz consumo de bateria e oferece personalização. |
 | **Sinônimos** | Tema Escuro |
@@ -317,7 +317,7 @@ Para a elaboração deste léxico do sistema eGDF, adotou-se a notação do Léx
 
 | Campo     | Descrição |
 |-----------|-----------|
-| **Símbolo**   | [Ajuste de Acessibilidade](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/analise_documentos.md#ajuste-de-acessibilidade---ad08) |
+| **Símbolo**   | [Ajuste de Acessibilidade](../elicitacao/tec_elicitacao/analise_documentos.md#ajuste-de-acessibilidade---ad08) |
 | **Noção**     | Funcionalidade que permite aumentar ícones e o tamanho da fonte no aplicativo por meio de um botão. |
 | **Impacto**   | Melhora a usabilidade e a experiência para usuários com deficiência visual ou idosos. |
 | **Sinônimos** | Ampliar Fonte, Aumentar Ícones |
@@ -334,7 +334,7 @@ Para a elaboração deste léxico do sistema eGDF, adotou-se a notação do Léx
 
 | Campo     | Descrição |
 |-----------|-----------|
-| **Símbolo**   | [Idioma](https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/elicitacao/tec_elicitacao/brainstorming.md#anchor_BS) |
+| **Símbolo**   | [Idioma](../elicitacao/tec_elicitacao/brainstorming.md#anchor_BS) |
 | **Noção**     | Configuração de linguagem do aplicativo, permitindo sua utilização em diferentes idiomas. |
 | **Impacto**   | Permite que usuários de diferentes nacionalidades utilizem o sistema em seu idioma preferido. |
 | **Sinônimos** | Linguagem |

--- a/docs/modelagem/lexico.md
+++ b/docs/modelagem/lexico.md
@@ -75,7 +75,7 @@ Para a elaboração deste léxico do sistema eGDF, adotou-se a notação do Léx
 
 <p style="text-align: center"><b>Tabela 3:</b> Léxico de Login</p>
 
-<font size="3"><p style="text-align: center">Fonte: Elaborado pelos autores (<a href="https://github.com/navicg">Ana Vitória</a>, <a href="https://github.com/KarolineLuz">Karoline Luz</a> e <a href="https://github.com/Luizaxx">Luiza da Silva Pugas</a>, 2025).</p></font>
+<font size="3"><p style="text-align: center">Fonte: Elaborado pelos autores (<a href="https://github.com/navicg">Ana Vitória</a> e <a href="https://github.com/Luizaxx">Luiza da Silva Pugas</a>, 2025).</p></font>
 
 
 

--- a/docs/modelagem/lexico.md
+++ b/docs/modelagem/lexico.md
@@ -171,7 +171,7 @@ Para a elaboração deste léxico do sistema eGDF, adotou-se a notação do Léx
 
 <p style="text-align: center"><b>Tabela 9:</b> Léxico de Funcionalidades Educacionais</p>
 
-<font size="3"><p style="text-align: center">Fonte: Elaborado pelos autores (<a href="https://github.com/lucasarruda9">Lucas Mendonça</a> e <a href="https://github.com/KarolineLuz">Karoline Luz</a>, 2025).</p></font>
+<font size="3"><p style="text-align: center">Fonte: Elaborado pelos autores (<a href="https://github.com/lucasarruda9">Lucas Mendonça</a>, 2025).</p></font>
 
 ---
 
@@ -187,7 +187,7 @@ Para a elaboração deste léxico do sistema eGDF, adotou-se a notação do Léx
 
 <p style="text-align: center"><b>Tabela 10:</b> Léxico de Mapa Interativo</p>
 
-<font size="3"><p style="text-align: center">Fonte: Elaborado pela autora (<a href="https://github.com/Luizaxx">Luiza da Silva Pugas</a>, 2025).</p></font>
+<font size="3"><p style="text-align: center">Fonte: Elaborado pela autora (<a href="https://github.com/KarolineLuz">Karoline Luz</a>, 2025).</p></font>
 
 ----
 
@@ -203,7 +203,7 @@ Para a elaboração deste léxico do sistema eGDF, adotou-se a notação do Léx
 
 <p style="text-align: center"><b>Tabela 11:</b> Léxico de Assistente Virtual</p>
 
-<font size="3"><p style="text-align: center">Fonte: Elaborado pelo autor (<a href="https://github.com/ArtyMend07">Artur Mendonça</a>, 2025).</p></font>
+<font size="3"><p style="text-align: center">Fonte: Elaborado pelo autor (<a href="https://github.com/ArtyMend07">Artur Mendonça</a> e <a href="https://github.com/Luizaxx">Luiza da Silva Pugas</a>, 2025).</p></font>
 
 
 ---


### PR DESCRIPTION
# :rocket: Correção dos links no documento de Léxico

## :clipboard: Descrição
Esta PR corrige todos os links no documento de Léxico para que funcionem corretamente no GitHub Pages, substituindo links absolutos por links relativos.

## :wrench: Tarefas Realizadas
- [x] Substituição de todos os links absolutos por links relativos no arquivo lexico.md
- [x] Verificação da sintaxe dos links para garantir compatibilidade com GitHub e GitHub Pages

## :pushpin: Problema Relacionado
Fixes #XX - Links quebrados no documento de Léxico no GitHub Pages

## :mag: Mudanças Realizadas
Todos os links no documento de Léxico foram modificados de URLs absolutas do GitHub (formato `https://github.com/Requisitos-de-Software/2025.1-e-GDF/blob/main/docs/...`) para links relativos (formato `../elicitacao/tec_elicitacao/...`). Esta mudança garante que os hyperlinks funcionem corretamente tanto na visualização no GitHub quanto na página publicada pelo GitHub Pages.

## :bulb: Observações Adicionais
Os links relativos são mais flexíveis e permitem que a documentação seja navegável independentemente da plataforma em que está sendo visualizada. Esta alteração não afeta o conteúdo do documento, apenas a forma como os links são construídos.

## :busts_in_silhouette: Revisores
- [Lucas Mendonça] (@lucasarruda9)