### PR TITLE
docs: Adicionando documentação da ata 9 (23/05/2025)

### DIFF
--- a/docs/atas/ata9.md
+++ b/docs/atas/ata9.md
@@ -1,0 +1,59 @@
+### Local
+Reunião realizada online via **Microsoft Teams**.
+
+### Horário da Reunião
+|          | Data       | Início | Término |
+|----------|------------|--------|---------|
+| Previsto | 23/05/2025 | 20:00  | 21:00   |
+| Realizado| 23/05/2025 | 19:10  | 19:36   |
+
+## Participantes presentes:
+- [x] [Ana Victória Guedes da Costa](https://github.com/navicg)  
+- [x] [Artur Mendonça Arruda](https://github.com/ArtyMend07)  
+- [x] [Gabriel Lopes](https://github.com/BrzGab)  
+- [x] [João Marcos Moraes de Andrade](https://github.com/JJOAOMARCOSS)  
+- [x] [Karoline Luz da Conceição](https://github.com/KarolineLuz)  
+- [x] [Lucas Mendonça Arruda](https://github.com/lucasarruda9)  
+- [x] [Luiza da Silva Pugas](https://github.com/Luizaxx)  
+
+## Pauta
+- Definição de quem inicia os documentos de **Requisitos Não Funcionais (NFR)**, **Histórias de Usuário** e **Backlog**.  
+- Distribuição dos requisitos funcionais e não funcionais entre os integrantes. 
+- Data da entrega 4.   
+
+## Decisões
+1. **Divisão de responsabilidades para início dos documentos principais**  
+   - **Requisitos Não Funcionais (NFR):**  
+     - [Lucas Mendonça Arruda](https://github.com/lucasarruda9)  
+     - [João Marcos Moraes de Andrade](https://github.com/JJOAOMARCOSS)  
+     - [Luiza da Silva Pugas](https://github.com/Luizaxx)  
+   - **Histórias de Usuário:**  
+     - [Ana Victória Guedes da Costa](https://github.com/navicg)  
+     - [Karoline Luz da Conceição](https://github.com/KarolineLuz)  
+   - **Backlog:**  
+     - [Artur Mendonça Arruda](https://github.com/ArtyMend07)  
+     - [Gabriel Lopes](https://github.com/BrzGab)  
+
+2. **Distribuição de requisitos**  
+   - Cada integrante receberá **6 requisitos funcionais** e **1 requisito não funcional** para detalhamento e rastreabilidade no artefato final. A distribuição ficou organizada da seguinte forma:  
+     - **Ana Victória Guedes da Costa:** 6 RF + 1 RNF  
+     - **Artur Mendonça Arruda:** 6 RF + 1 RNF  
+     - **Gabriel Lopes:** 6 RF + 1 RNF  
+     - **João Marcos Moraes de Andrade:** 6 RF + 1 RNF  
+     - **Karoline Luz da Conceição:** 6 RF + 1 RNF  
+     - **Lucas Mendonça Arruda:** 6 RF + 1 RNF  
+     - **Luiza da Silva Pugas:** 6 RF + 1 RNF  
+
+## Link da reunião
+[Link da nona reunião](https://youtu.be/lQY-0yWOFKY)
+
+## Bibliografia
+**BRASIL. Ministério da Ciência, Tecnologia e Inovação. Ata de Reunião. Brasília: MCTI, [s.d.]. Disponível em**: https://pdp.mctic.gov.br/MCTI-PDP/guidances/examples/Ata%20Reuniao_21C35EC2.html?nodeId=7c6d2e0. **Acesso em: 31 maio 2025**.
+
+## Próxima Reunião
+**06/06/2025** às **20h** (online via Microsoft Teams)
+
+## Histórico de versão
+| Versão | Data       | Descrição             | Autor(es)                                       | Revisor(es)                                    | Data de revisão |
+|--------|------------|-----------------------|-------------------------------------------------|------------------------------------------------|-----------------|
+| 1.0    | 31/05/2025 | Ata da 9ª Reunião     | [Artur Mendonça Arruda](https://github.com/ArtyMend07) | [Gabriel Lopes](https://github.com/BrzGab)    | 31/05/2025      |


### PR DESCRIPTION
# :rocket: Adiciona Ata da 9ª Reunião

## :clipboard: Descrição
Esta Pull Request adiciona a ata referente à 9ª reunião do grupo, realizada no dia **23/05/2025**. O documento registra a data, horário, local da reunião, participantes presentes, pauta discutida, decisões tomadas, link da gravação, bibliografia utilizada e informações sobre a próxima reunião.

## :wrench: Tarefas Realizadas
- [x] Registro de data, horário e participantes
- [x] Documentação das pautas e decisões
- [x] Inclusão do link da reunião gravada
- [x] Adição do histórico de versão

## :pushpin: Problema Relacionado
Closes #178

## :bulb: Observações Adicionais
O documento segue o padrão adotado nas atas anteriores e está em conformidade com a estrutura oficial indicada pela bibliografia de referência.

## :busts_in_silhouette: Revisores
- Gabriel Lopes (@BrzGab)
